### PR TITLE
Debian: install apt-transport-https before using HTTPs repos

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -10,8 +10,14 @@
     state: present
   with_items: '{{ stackstorm_debian_repo_info.repos }}'
 
+- name: debian | installing apt-transport-https
+  apt:
+    name: apt-transport-https
+    state: present
+
 - name: debian | installing stackstorm packages
   apt:
     name: "{{ item }}"
     state: present
+    update_cache: yes
   with_items: '{{ stackstorm_debian_packages }}'


### PR DESCRIPTION
Closes #1.

Also add an `update_cache: yes`, so that both the new package and the new repositories are picked up.
